### PR TITLE
Freeze dependency versions

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,4 @@
+[tools]
+python = "3.8"
+ninja = "1.12"
+clang = "19.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ tensorboard<2.15
 tensorboardX<2.7
 choix<0.4
 PySide2<5.16
+six<1.17

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-torch
-numpy
-cython
-tensorboard
-tensorboardX
-choix
-PySide2
+torch<2.5
+numpy<1.25
+Cython<3.1
+tensorboard<2.15
+tensorboardX<2.7
+choix<0.4
+PySide2<5.16


### PR DESCRIPTION
The Python ecosystem has updated a bit since this code was written a few years ago -- a new Numpy major version, ordinary Python breaking changes, various deprecations, PySide segfaults if you use a Python version that's too new, the works. This leads to a lot of dependency chasing when getting spun up. This PR just tries to lock everything to minor versions that seem to work on my machine after trial and error, using `requirements.txt` for the Python dependencies and a [Mise](https://mise.jdx.dev/) file for the toolchain dependencies.

- Resolves #7 
- Resolves #32 